### PR TITLE
Add checks to ensure there are always pokeballs available to use

### DIFF
--- a/pgoapi/location.py
+++ b/pgoapi/location.py
@@ -1,6 +1,6 @@
 # Do NOT use this bot while signed into your acccount with your phone -TomTheBotter
 
-# import logging
+#import logging
 from geopy.geocoders import GoogleV3
 from gmaps.errors import GmapException
 from gmaps.directions import Directions
@@ -35,13 +35,13 @@ def get_route(start,end, use_google = False, gmaps_api_key = None):
                 steps = d[0]['legs'][0]['steps']
                 return [(step['end_location']["lat"],step['end_location']["lng"]) for step in steps]
             except GmapException as err:
-                log.error('Gmaps API error with key index %s trying next key', globalvars.apikeyindex)
+                #log.error('Gmaps API error with key index %s trying next key', globalvars.apikeyindex)
                 counter += 1
                 if globalvars.apikeyindex == len(gmaps_api_key) - 1: #if we are at the end of the API key list try the first one again
                     globalvars.apikeyindex = 0
                 else:
                     globalvars.apikeyindex += 1
-        log.error('All Gmaps API Keys are returning an error: Raising exception')
+        #log.error('All Gmaps API Keys are returning an error: Raising exception')
         raise
     else:
         return [destination]

--- a/pgoapi/location.py
+++ b/pgoapi/location.py
@@ -1,6 +1,6 @@
 # Do NOT use this bot while signed into your acccount with your phone -TomTheBotter
 
-#import logging
+# import logging
 from geopy.geocoders import GoogleV3
 from gmaps.errors import GmapException
 from gmaps.directions import Directions

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -426,7 +426,7 @@ class PGoApi:
                     sleep(2) # If you want to make it faster, delete this line... would not recommend though
                     return catch_attempt
                 elif capture_status == 2:
-                    self.log.info("Pokemon %s is too wild", self.pokemon_names[str(resp['pokemon_data']['pokemon_id'])])
+                    self.log.info("Pokemon %s is too wild", self.pokemon_names[str(pokemon['pokemon_id'])])
                     if self._pokeball_type < self.MAX_BALL_TYPE:
                         self._pokeball_type += 1
                 elif capture_status != 2:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -508,7 +508,7 @@ class PGoApi:
                     sleep(4) # If you want to make it faster, delete this line... would not recommend though
                     pass
             else:
-                self.log.info("Less than 10 Pokeballs: Entering pokestops only")
+                self.log.info("Less than 10 Poke Balls or 5 Great/Ultra Balls: Entering pokestops only")
             self.spin_near_fort()
 
     @staticmethod

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -118,6 +118,7 @@ class PGoApi:
         self._req_method_list = []
         self._heartbeat_number = 5
         self.pokemon_names = pokemon_names
+        self.pokeballs = [50,50,50,50] #pokeball counts. set to 50 to avoid possibility of triggering farm mode at startup
 
     def call(self):
         if not self._req_method_list:
@@ -309,6 +310,8 @@ class PGoApi:
         all_actual_item_count = 0
         all_actual_items = sorted([x for x in all_actual_items if "count" in x], key=lambda x: x["item_id"])
         for xiq in all_actual_items:
+            if 1 <= xiq["item_id"] <= 4: #save counts of pokeballs
+                self.pokeballs[xiq["item_id"]] = xiq["count"]
             true_item_name = INVENTORY_DICT[xiq["item_id"]]
             all_actual_item_str += "Item_ID " + str(xiq["item_id"]) + "\titem count " + str(xiq["count"]) + "\t(" + true_item_name + ")\n"
             all_actual_item_count += xiq["count"]
@@ -499,9 +502,13 @@ class PGoApi:
         while True:
             self.heartbeat()
             sleep(1) # If you want to make it faster, delete this line... would not recommend though
-            while self.catch_near_pokemon():
-                sleep(4) # If you want to make it faster, delete this line... would not recommend though
-                pass
+            #make sure we always have at least 10 pokeballs, 5 great balls, and 5 ultra balls
+            if self.pokeballs[0] > 9 and self.pokeballs[1] > 4 and self.pokeballs[2] > 4:
+                while self.catch_near_pokemon():
+                    sleep(4) # If you want to make it faster, delete this line... would not recommend though
+                    pass
+            else:
+                self.log.info("Less than 10 Pokeballs: Entering pokestops only")
             self.spin_near_fort()
 
     @staticmethod

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -40,17 +40,17 @@ BAD_ITEM_IDS = [
 ]
 
 # Minimum amount of the bad items that you should have ... Modify based on your needs ... like if you need to battle a gym?
-MIN_BAD_ITEM_COUNTS = {Inventory.ITEM_POKE_BALL: 50,
-                       Inventory.ITEM_GREAT_BALL: 50,
-                       Inventory.ITEM_ULTRA_BALL: 50,
+MIN_BAD_ITEM_COUNTS = {Inventory.ITEM_POKE_BALL: 85,
+                       Inventory.ITEM_GREAT_BALL: 85,
+                       Inventory.ITEM_ULTRA_BALL: 85,
                        Inventory.ITEM_POTION: 5,
                        Inventory.ITEM_SUPER_POTION: 5,
-                       Inventory.ITEM_HYPER_POTION: 50,
-                       Inventory.ITEM_MAX_POTION: 50,
-                       Inventory.ITEM_RAZZ_BERRY: 25,
+                       Inventory.ITEM_HYPER_POTION: 5,
+                       Inventory.ITEM_MAX_POTION: 5,
+                       Inventory.ITEM_RAZZ_BERRY: 50,
                        Inventory.ITEM_BLUK_BERRY: 10,
                        Inventory.ITEM_NANAB_BERRY: 10,
-                       Inventory.ITEM_REVIVE: 15}
+                       Inventory.ITEM_REVIVE: 5}
 
 # Candy needed to evolve pokemon
 CANDY_NEEDED_TO_EVOLVE = {10: 11,  # Caterpie
@@ -118,7 +118,7 @@ class PGoApi:
         self._req_method_list = []
         self._heartbeat_number = 5
         self.pokemon_names = pokemon_names
-        self.pokeballs = [50,50,50,50] #pokeball counts. set to 50 to avoid possibility of triggering farm mode at startup
+        self.pokeballs = [0,0,0,0] #pokeball counts. set to 0 to ensure that even if the bot is started with 0 pokeballs it will continue without error
 
     def call(self):
         if not self._req_method_list:
@@ -235,8 +235,10 @@ class PGoApi:
                 self.heartbeat()
                 self.log.info("Sleeping before next heartbeat")
                 sleep(2) # If you want to make it faster, delete this line... would not recommend though
-                while self.catch_near_pokemon():
-                    sleep(1) # If you want to make it faster, delete this line... would not recommend though
+                #make sure we always have at least 10 pokeballs, 5 great balls, and 5 ultra balls
+                if self.pokeballs[1] > 9 and self.pokeballs[2] > 4 and self.pokeballs[3] > 4:
+                    while self.catch_near_pokemon():
+                        sleep(1) # If you want to make it faster, delete this line... would not recommend though
 
     def spin_near_fort(self):
         map_cells = self.nearby_map_objects().get('responses', {}).get('GET_MAP_OBJECTS', {}).get('map_cells', {})
@@ -260,7 +262,8 @@ class PGoApi:
                 position = self._posf
                 resp = self.disk_encounter(encounter_id=encounter_id, fort_id=fort_id, player_latitude=position[0], player_longitude=position[1]).call()['responses']['DISK_ENCOUNTER']
                 self.log.debug('Encounter response is: %s', resp)
-                self.disk_encounter_pokemon(fort['lure_info'])
+                if self.pokeballs[1] > 9 and self.pokeballs[2] > 4 and self.pokeballs[3] > 4:
+                    self.disk_encounter_pokemon(fort['lure_info'])
             return True
         else:
             self.log.error("No fort to walk to!")
@@ -503,7 +506,7 @@ class PGoApi:
             self.heartbeat()
             sleep(1) # If you want to make it faster, delete this line... would not recommend though
             #make sure we always have at least 10 pokeballs, 5 great balls, and 5 ultra balls
-            if self.pokeballs[0] > 9 and self.pokeballs[1] > 4 and self.pokeballs[2] > 4:
+            if self.pokeballs[1] > 9 and self.pokeballs[2] > 4 and self.pokeballs[3] > 4:
                 while self.catch_near_pokemon():
                     sleep(4) # If you want to make it faster, delete this line... would not recommend though
                     pass

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -281,7 +281,7 @@ class PGoApi:
 
     def nearby_map_objects(self):
         position = self.get_position()
-        neighbors = getNeighbors(self._posf)
+        neighbors = get_neighbors(self._posf)
         return self.get_map_objects(latitude=position[0], longitude=position[1], since_timestamp_ms=[0]*len(neighbors), cell_id=neighbors).call()
     
     def attempt_catch(self,encounter_id,spawn_point_guid,ball_type):


### PR DESCRIPTION
Currently the bot will just keep trying to throw non-existent pokeballs if it runs out throwing this error: "Main loop has an ERROR, restarting 'NoneType' object has no attribute 'getitem'"

I added checks to make sure that the bot always has pokeballs available. When it is below 10 pokeballs, 5 great balls, or 5 ultra balls the bot will only go to pokestops and will ignore all pokemon.

I also upped the limits on pokeballs and decreased the limit on other junk items (potions, revives).